### PR TITLE
Update install snippet to use pyenv root

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pyenv.
 
 Make sure you have pyenv 0.4.0 or later, then run:
 
-    git clone https://github.com/pyenv/pyenv-which-ext.git ~/.pyenv/plugins/pyenv-which-ext
+    git clone https://github.com/pyenv/pyenv-which-ext.git $(pyenv root)/plugins/pyenv-which-ext
 
 
 ### Installing with Homebrew (for OS X users)


### PR DESCRIPTION
This is quite helpful if you're installing Pyenv into a non-standard location, and/or using a helper like Anyenv or similar.